### PR TITLE
MAINT: Remove nbsphinx and pandoc

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Install dependencies
         shell: bash -el {0}
         run: |
-          sudo apt-get install pandoc
           python -m pip install --upgrade pip
           pip install numpy matplotlib scipy NEURON
           pip install '.[gui, docs]'

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,7 +37,7 @@ clean:
 	rm -rf modules/*
 
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -D nbsphinx_execute=never -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 -D -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'numpydoc',
-    'nbsphinx',
     'sphinx_copybutton',
     'gh_substitutions'  # custom extension, see ./sphinxext/gh_substitutions.py
 ]
@@ -245,28 +244,3 @@ sphinx_gallery_conf = {
                }
 }
 
-suppress_warnings = [
-    'nbsphinx',
-]
-
-nbsphinx_execute = 'always'
-
-nbsphinx_prolog = """
-.. raw:: html
-
-    <style>
-        .body {
-            max-width: 100% !important;
-        }
-        .nbinput.container {
-            padding-top: 5px;
-            display: none !important;
-        }
-        div.nboutput.container div.prompt {
-            display: none !important;
-        }
-        div.nboutput.container div.output_area.stderr {
-            display: none !important;
-        }
-    </style>
-"""

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         'parallel': ['joblib', 'psutil'],
         'test': ['flake8', 'pytest', 'pytest-cov', ],
         'docs': ['mne', 'nibabel', 'pooch', 'tdqm',
-                 'sphinx', 'nbsphinx', 'sphinx-gallery',
+                 'sphinx', 'sphinx-gallery',
                  'sphinx_bootstrap_theme', 'sphinx-copybutton',
                  'pillow', 'numpydoc',
                  ],


### PR DESCRIPTION
We no longer need these dependencies for building the documentation, removing to simplify the installation